### PR TITLE
Implement Time-based splitter

### DIFF
--- a/flow_config.py
+++ b/flow_config.py
@@ -23,7 +23,7 @@ from labeling import produce_target
 from preprocessing import baseline_preprocess, drop_known_columns, preprocess
 from preprocessors import NoFitPreProcessor
 from raw_data import get_raw_data
-from raw_data_folding import BaseTrainValTestSplitter
+from raw_data_folding import BaseTrainValTestSplitter, AllUntilMonthSplitter
 
 get_raw_data_packs = {
     "V0": {"function": get_raw_data},
@@ -33,7 +33,9 @@ get_raw_data_packs = {
 cross_validation_packs = {
     "TrainTrainTest": {"class": BaseTrainValTestSplitter,
                        "args": {}
-                       }
+                       },
+    "AllUntilMonthSplitter": {"class": AllUntilMonthSplitter,
+                              "args": {}}
 }
 
 # from name to arguments for a pipeline

--- a/raw_data_folding.py
+++ b/raw_data_folding.py
@@ -1,6 +1,8 @@
 """
 Split raw data into folds
 """
+import pandas as pd
+from constants import *
 from custom_types import RawFold
 
 
@@ -14,3 +16,43 @@ class BaseTrainValTestSplitter:
 
     def split(self, train_rawdata, test_rawdata) -> list[RawFold]:
         return [RawFold(train_rawdata, train_rawdata, test_rawdata)]
+
+
+class AllUntilMonthSplitter(BaseTrainValTestSplitter):
+    """
+    For each month-year in the test set,
+    the validation set will be taken from raw training samples with the same month and year,
+    and the training set will be all raw training samples until that month and year.
+    """
+    def __init__(self):
+        super().__init__()
+
+    def split(self, train_rawdata, test_rawdata) -> list[RawFold]:
+        train_rawdata_dt = self._convert_month_year_to_dt(train_rawdata)
+        test_rawdata_dt = self._convert_month_year_to_dt(test_rawdata)
+
+        test_unique_dts = test_rawdata_dt['dt'].unique().tolist()
+        all_folds = []
+
+        for month_time_frame in test_unique_dts:
+            test_rawdata_in_frame = test_rawdata[test_rawdata_dt['dt'] == month_time_frame]
+
+            val_rawdata_in_frame = train_rawdata[train_rawdata_dt['dt'] == month_time_frame]
+
+            train_rawdata_until_frame = train_rawdata[train_rawdata_dt['dt'] < month_time_frame]
+
+            if len(train_rawdata_until_frame) == 0:
+                # this can happen for January 2006, because both the raw training set and test set start from this month
+                index_cuttoff = int(0.8 * len(val_rawdata_in_frame))
+                train_rawdata_until_frame = val_rawdata_in_frame.iloc[:index_cuttoff]
+                val_rawdata_in_frame = val_rawdata_in_frame.iloc[index_cuttoff:]
+
+            all_folds.append(RawFold(train_rawdata_until_frame, val_rawdata_in_frame, test_rawdata_in_frame))
+
+        return all_folds
+
+    @staticmethod
+    def _convert_month_year_to_dt(df: pd.DataFrame):
+        df = df.copy()
+        df['dt'] = pd.to_datetime(df[YrSold].astype(str) + df[MoSold].astype(str), format='%Y%m')
+        return df


### PR DESCRIPTION
This splitter will split the data to folds, one fold for each month frame in the test set.
The validation set will be all the training samples in this month frame.
The training set will be all training samples until that month frame.